### PR TITLE
docs(ch10): Add join() after interrupt in virtual thread example and …

### DIFF
--- a/ch10.md
+++ b/ch10.md
@@ -297,6 +297,11 @@ public class InterruptExample {
         }
 
         thread.interrupt();
+        try {
+            thread.join();
+        }  catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 }
 ```
@@ -304,7 +309,7 @@ public class InterruptExample {
 In this example, we create a virtual thread that goes to sleep for 5 seconds. The main thread sleeps for 2 seconds and then calls `interrupt()` on the other thread.
 
 When `interrupt()` is called, it sets the interrupted status of the target thread. If the target thread is sleeping or waiting, it will immediately throw an `InterruptedException`. The thread can then handle the interruption appropriately.
-
+Because virtual threads are daemon threads by default (they don't prevent the JVM from exiting), adding `join()` ensures that the main thread waits for the virtual thread to complete its work (handling the interruption) before the program terminates.
 In the example, the output will be:
 ```
 Thread is going to sleep


### PR DESCRIPTION
The issue in the `InterruptExample` snippet is that the main thread doesn't wait for the virtual thread to complete its execution before terminating. This can lead to unpredictable behavior where the virtual thread might not have enough time to properly handle the InterruptedException and execute `System.out.println("Thread was interrupted")`.
Fixed by adding `thread.join()` after calling `thread.interrupt()` to ensure the main thread waits for the virtual thread to complete.