### PR TITLE
correct index in string builder example

### DIFF
--- a/ch04.md
+++ b/ch04.md
@@ -1497,11 +1497,11 @@ Furthermore, `StringBuilder` methods can be chained together, similar to `String
 
 ```java
 StringBuilder sb = new StringBuilder("Hello");
-sb.append(" World").insert(0, "Hey, ").delete(4, 9);
+sb.append(" World").insert(0, "Hey, ").delete(4, 10);
 System.out.println(sb);  // Prints "Hey, World"
 ```
 
-In this example, we start with a `StringBuilder` containing `"Hello"`. We then append `" World"` to it, insert `"Hey, "` at the beginning, and delete the characters from index 4 to 8 (inclusive). Each of these operations modifies the same `StringBuilder` instance.
+In this example, we start with a `StringBuilder` containing `"Hello"`. We then append `" World"` to it, insert `"Hey, "` at the beginning, and delete the characters from index 4 to 9 (inclusive). Each of these operations modifies the same `StringBuilder` instance.
 
 You can create a `StringBuilder` in a few ways:
 


### PR DESCRIPTION
Correct index in string builder example:
- Before: 
```
StringBuilder sb = new StringBuilder("Hello");
sb.append(" World").insert(0, "Hey, ").delete(4, 9);
```
Result in Hey,o World

- After:
```
StringBuilder sb = new StringBuilder("Hello");
sb.append(" World").insert(0, "Hey, ").delete(4, 10);
```
Result in Hey, World