### PR TITLE
Fix correct wording in java 21 will throw compile error, not warn

### DIFF
--- a/ch05.md
+++ b/ch05.md
@@ -603,7 +603,7 @@ String result = switch (obj) {
 System.out.println(result); // Outputs: Long string
 ```
 
-If we were to put the `case String s` before `case String s when s.length() > 5`, the guard would never be reached, and the compiler would warn us about an unreachable case.
+If we were to put the `case String s` before `case String s when s.length() > 5`, the guard would never be reached, and the compiler would report a compile-time error about an unreachable case.
 
 Pattern matching in switch also introduces a more elegant way to handle `null` values:
 


### PR DESCRIPTION
The context:

```
Object obj = "Hello";
String result = switch (obj) {
    case String s when s.length() > 5 -> "Long string";
    case String s -> "Short string";
    case CharSequence cs -> "Some other CharSequence";
    default -> "Not a CharSequence";
};
System.out.println(result); // Outputs: Long string
```
If we were to put the case String s before case String s when s.length() > 5, the guard would never be reached, and the compiler would **warn us** about an unreachable case.

Correct wording: it will result in compilation error, not just warn