### PR TITLE
Fix Ch. 2: subclasses can also access same-package (default) members

### DIFF
--- a/ch02.md
+++ b/ch02.md
@@ -476,7 +476,7 @@ public class ChocolateChipCookie extends Cookie {
 
 Here, `ChocolateChipCookie` is a subclass of `Cookie`. It inherits the `flavor` and `size` fields and the `eat()` method. The subclass can declare its own methods, like how `ChocolateChipCookie` declares the `addChips()` method.
 
-However, a subclass cannot directly access `private` members of its superclass. Subclasses can only access `protected` and `public` members of the superclass directly. To access `private` fields, the superclass must provide `public` or `protected` accessors.
+However, a subclass cannot directly access the `private` members of its superclass. It can directly access the `public` and `protected` members. It can also access package-private (default) members when the subclass is in the same package. To reach `private` fields, the superclass must provide `public` or `protected` accessors.
 
 One important thing to know is that in Java, a class can only extend from one class due to the design choice to avoid the complexity and ambiguity associated with multiple inheritance. In other words, multiple inheritance, where a class can extend more than one class, can lead to:
 
@@ -2510,7 +2510,7 @@ void myMethod() {
 
 **4. Which of the following statements correctly describe the use of inheritance in Java? (Choose all that apply.)**
 
-**A)** Subclasses can only access `protected` and `public` members of their superclass directly.  
+**A)** Subclasses can directly access the `public` and `protected` members of their superclass, and package-private members when they are in the same package.  
 **B)** In Java, a class can extend multiple classes to achieve multiple inheritance.  
 **C)** The `extends` keyword is used in Java to create a subclass that inherits from a superclass.  
 **D)** A subclass in Java can directly access `private` members of its superclass.

--- a/ch02a.md
+++ b/ch02a.md
@@ -71,14 +71,14 @@ exam_objectives:
 
 **Explanation:**
 
-- **A)** The `extends` keyword is used in Java to create a subclass that inherits from a superclass.
-  - This option is correct. Subclasses can directly access `protected` and `public` members of their superclass. This accessibility allows subclasses to leverage and extend the functionality provided by the superclass while maintaining encapsulation of `private` members.
+- **A)** Subclasses can directly access the `public` and `protected` members of their superclass, and package-private members when they are in the same package.
+  - This option is correct. A subclass can use the `public` and `protected` members of its superclass directly. Package-private members work too, but only when the subclass is in the same package. `private` members stay off-limits, so the superclass must expose them through accessors.
 
 - **B)** In Java, a class can extend multiple classes to achieve multiple inheritance.
   - This option is incorrect. Java does not support multiple inheritance for classes. A class in Java can only extend one other class, preventing complications like the diamond problem and the complexity associated with multiple inheritance.
 
-- **C)** Subclasses can only access `protected` and `public` members of their superclass directly.
-  - This option is correct. The `extends` keyword is indeed used to define a subclass that inherits properties and behaviors from a single superclass, establishing an *is-a* relationship between the subclass and the superclass. This is a fundamental concept in Java's implementation of inheritance.
+- **C)** The `extends` keyword is used in Java to create a subclass that inherits from a superclass.
+  - This option is correct. `extends` creates a subclass that inherits the fields and methods of a single superclass, giving an is-a relationship between them.
 
 - **D)** A subclass in Java can directly access `private` members of its superclass.
   - This option is incorrect. A subclass cannot directly access `private` members of its superclass. Instead, it can access them through `public` or `protected` accessors provided by the superclass. This encapsulation principle ensures a controlled interaction with the superclass's state.


### PR DESCRIPTION
Hi Esteban, thank you for the guide, it has helped me a lot.

Small correction in Chapter 2. A few places say a subclass can only access the protected and public members of its superclass. That leaves out one case: a subclass can also access package-private (default) members when it is in the same package.

What I changed:
- The sentence in the Inheritance section.
- Option A in Practice Question 4, so it reads as a true statement.
- The Q4 answer to match, and a small mix-up where the A and C explanations had their option text swapped.

Access in short: public and protected always, package-private only in the same package, private never (it needs accessors).